### PR TITLE
Add Adminer namespace

### DIFF
--- a/quickfilter.php
+++ b/quickfilter.php
@@ -15,7 +15,7 @@ class AdminerQuickFilterTables
 	}
 	public function head()
 	{   
-		$nonce = get_nonce();
+		$nonce = Adminer\get_nonce();
 ?>
 
 		<style>


### PR DESCRIPTION
Adminer 5 wrapped itself into a namespace and plugins now need to call Adminer's functions via this namespace.